### PR TITLE
Remove outdated keys in appconfig

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -9,8 +9,8 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   version: '1.0.0',
   extra: {
     settingsStoredKey: 'setting',
-    googleMapsAPI: 'AIzaSyDmMnmiEOJmo-iH5--shOV-T7vm-Cl2aT0',
-    cityMapperAPI: '6jpwkWlakoUlsL4yzquR9L9xuAb4v6ng',
+    googleMapsAPI: '',
+    cityMapperAPI: '',
     eas: {
       projectId: 'f9d59e35-0f83-450d-ad37-273dce41a868'
     }


### PR DESCRIPTION
These keys really should not be committed into github in the first place, since it will live in history.

But since these are legacy keys and no longer valid, we can just leave it in our github history, but still remove it from config so that future devs know that they need to input their own keys for dev environments & prod distributions.

- Google maps key -> Rotated and no longer able to be used
- City Mapper -> Free API went down as of June 2023 (https://citymapper.com/news/2596/sdks-and-apis-come-to-an-end)