### PR TITLE
fix: fix unique 'key' prop warning

### DIFF
--- a/src/common/components/TransitOptionCard.tsx
+++ b/src/common/components/TransitOptionCard.tsx
@@ -1,6 +1,6 @@
 import { Feather } from '@expo/vector-icons'
 import { styled } from 'nativewind'
-import { useMemo } from 'react'
+import { Fragment, useMemo } from 'react'
 import { Pressable, Text, View } from 'react-native'
 
 import TransitTypePill from './TransitTypePill'
@@ -41,7 +41,7 @@ const TransitOptionCard = ({
         <View className='flex flex-row flex-wrap items-center pb-6 pt-4'>
           {steps.map((step, i) => {
             return (
-              <>
+              <Fragment key={i}>
                 <TransitTypePill
                   travelMode={step.travelMode}
                   transitLine={step.transitLine}
@@ -51,7 +51,7 @@ const TransitOptionCard = ({
                     <Feather name='chevron-right' size={20} color='black' />
                   </View>
                 )}
-              </>
+              </Fragment>
             )
           })}
         </View>

--- a/src/pages/TransitOptions.tsx
+++ b/src/pages/TransitOptions.tsx
@@ -90,6 +90,7 @@ const TransitOptions = ({ navigation, route }: Props) => {
         )}
         {transitOptions.map((t, i) => (
           <TransitOptionCard
+            key={i}
             index={i}
             googleRouteStepsOverview={t}
             onPress={() => {


### PR DESCRIPTION
This PR fixes 'Warning: Each child in a list should have a unique "key" prop.'

<img width="903" alt="image" src="https://github.com/user-attachments/assets/b8fd4b69-3a0d-4c1f-ab3e-7051d67f774f" />
