### PR TITLE
Remove provider prop from MapView to fix white screen issue on iOS

### DIFF
--- a/src/common/locationSelector/GoogleMapView.tsx
+++ b/src/common/locationSelector/GoogleMapView.tsx
@@ -10,7 +10,7 @@ import {
   StatusBar
 } from 'react-native'
 import Autocomplete from 'react-native-autocomplete-input'
-import MapView, { Marker, PROVIDER_GOOGLE } from 'react-native-maps'
+import MapView, { Marker } from 'react-native-maps'
 import { MaterialIcons } from '@expo/vector-icons'
 
 import {
@@ -197,7 +197,6 @@ const GoogleMapView = ({ onLocationMarkerDrop, value }: Props) => {
       </View>
       <MapView
         ref={mapViewRef}
-        provider={PROVIDER_GOOGLE}
         style={styles.map}
         initialRegion={{
           latitude: 1.3521,


### PR DESCRIPTION
This PR removes the provider prop from the `MapView` component, allowing it to fall back to the default provider behavior. This resolves an issue on iOS where the map was not rendering and instead displayed a white screen. By omitting the provider prop, the map now renders correctly using the platform default.

Context:
- The provider prop was causing rendering issues on iOS.
- Removing it aligns with the recommended usage for default map behavior across platforms.
	
According to the MapView's documentation on the `provider` prop:
>The map framework to use. Either "google" for GoogleMaps, otherwise undefined to use the native map framework (MapKit in iOS and GoogleMaps in android).

MapView in iOS after the changes are applied:
<img width="342" alt="image" src="https://github.com/user-attachments/assets/e9e1c5e3-8db1-4b41-9cca-dc690697f195" />
