### PR TITLE
feat: persist last known location and updated at when PWID location sharing stops

### DIFF
--- a/packages/common/src/contexts/LocationSharingContext.native.tsx
+++ b/packages/common/src/contexts/LocationSharingContext.native.tsx
@@ -69,8 +69,8 @@ export const LocationSharingProvider: React.FC<{
         locationSubscription.current = null
       }
       setDestinationState(null)
-      // Clear PWID location from database
-      if (pwidPhoneNumber)
+      // Update database to reflect that location sharing ended
+      if (pwidPhoneNumber && hasSharedRef.current)
         stopPWIDLocationSharing(pwidPhoneNumber).catch((_err) => {})
     }
 

--- a/packages/common/src/contexts/LocationSharingContext.native.tsx
+++ b/packages/common/src/contexts/LocationSharingContext.native.tsx
@@ -182,7 +182,8 @@ export const LocationSharingProvider: React.FC<{
               await updatePWIDLocation(pwidPhoneNumber, {
                 lat: loc.coords.latitude,
                 lng: loc.coords.longitude,
-                updatedAt: Date.now()
+                updatedAt: Date.now(),
+                isSharing: true
               })
 
               // Use the ref for the latest destination

--- a/packages/common/src/contexts/LocationSharingContext.native.tsx
+++ b/packages/common/src/contexts/LocationSharingContext.native.tsx
@@ -12,8 +12,8 @@ import { Alert } from 'react-native'
 import notificationService from '../services/notificationService'
 import { getUserStorage } from '../services/storageService'
 import {
-  clearPWIDLocation,
   getUserData,
+  stopPWIDLocationSharing,
   updatePWIDLocation
 } from '../services/userService'
 import type { PWIDUser } from '../types'
@@ -71,7 +71,7 @@ export const LocationSharingProvider: React.FC<{
       setDestinationState(null)
       // Clear PWID location from database
       if (pwidPhoneNumber)
-        clearPWIDLocation(pwidPhoneNumber).catch((_err) => {})
+        stopPWIDLocationSharing(pwidPhoneNumber).catch((_err) => {})
     }
 
     const stopSharing = async () => {

--- a/packages/common/src/contexts/LocationSharingContext.web.tsx
+++ b/packages/common/src/contexts/LocationSharingContext.web.tsx
@@ -4,8 +4,8 @@ import React, { createContext, useCallback, useContext, useState } from 'react'
 import notificationService from '../services/notificationService'
 import { getUserStorage } from '../services/storageService'
 import {
-  clearPWIDLocation,
   getUserData,
+  stopPWIDLocationSharing,
   updatePWIDLocation
 } from '../services/userService'
 import type { PWIDUser } from '../types'
@@ -90,7 +90,7 @@ export const LocationSharingProvider: React.FC<{
         watchIdRef.current = null
       }
       if (pwidPhoneNumber) {
-        clearPWIDLocation(pwidPhoneNumber).catch(() => {})
+        stopPWIDLocationSharing(pwidPhoneNumber).catch(() => {})
       }
       return
     }
@@ -150,7 +150,7 @@ export const LocationSharingProvider: React.FC<{
         watchIdRef.current = null
       }
       if (pwidPhoneNumber) {
-        clearPWIDLocation(pwidPhoneNumber).catch(() => {})
+        stopPWIDLocationSharing(pwidPhoneNumber).catch(() => {})
         sendStopNotificationToCaregiver().catch(() => {})
       }
     }

--- a/packages/common/src/contexts/LocationSharingContext.web.tsx
+++ b/packages/common/src/contexts/LocationSharingContext.web.tsx
@@ -85,11 +85,12 @@ export const LocationSharingProvider: React.FC<{
   React.useEffect(() => {
     if (!isLocationSharing || !pwidPhoneNumber) {
       // Stop sharing
+      const wasSharing = watchIdRef.current !== null
       if (watchIdRef.current !== null) {
         navigator.geolocation.clearWatch(watchIdRef.current)
         watchIdRef.current = null
       }
-      if (pwidPhoneNumber) {
+      if (pwidPhoneNumber && wasSharing) {
         stopPWIDLocationSharing(pwidPhoneNumber).catch(() => {})
       }
       return
@@ -145,11 +146,12 @@ export const LocationSharingProvider: React.FC<{
     )
 
     return () => {
+      const wasSharing = watchIdRef.current !== null
       if (watchIdRef.current !== null) {
         navigator.geolocation.clearWatch(watchIdRef.current)
         watchIdRef.current = null
       }
-      if (pwidPhoneNumber) {
+      if (pwidPhoneNumber && wasSharing) {
         stopPWIDLocationSharing(pwidPhoneNumber).catch(() => {})
         sendStopNotificationToCaregiver().catch(() => {})
       }

--- a/packages/common/src/contexts/LocationSharingContext.web.tsx
+++ b/packages/common/src/contexts/LocationSharingContext.web.tsx
@@ -112,7 +112,8 @@ export const LocationSharingProvider: React.FC<{
           await updatePWIDLocation(pwidPhoneNumber!, {
             lat: position.coords.latitude,
             lng: position.coords.longitude,
-            updatedAt: Date.now()
+            updatedAt: Date.now(),
+            isSharing: true
           })
 
           // Check if arrived at destination

--- a/packages/common/src/pages/home/CaregiverHome.tsx
+++ b/packages/common/src/pages/home/CaregiverHome.tsx
@@ -60,7 +60,7 @@ export function CaregiverHome() {
   )
 
   const renderPWIDItem = (item: PWIDUser) => {
-    const isSharing = !!item.location
+    const isSharing = !!item.location?.isSharing
     const statusColor = isSharing ? '#CBF4DF' : '#F7CBC8'
     const statusTextColor = isSharing ? '#209D5E' : '#E13F33'
     const statusText = isSharing ? 'Online' : 'Offline'

--- a/packages/common/src/pages/track-pwid/TrackPWIDPage.tsx
+++ b/packages/common/src/pages/track-pwid/TrackPWIDPage.tsx
@@ -8,13 +8,7 @@ import { BackButton, Button, Text, View } from '../../components'
 import GoogleMapView from '../../components/mapView/GoogleMapView'
 import { listenToPWIDLocation } from '../../services/userService'
 import type { MarkerData } from '../../stores/onboardingStore'
-
-interface Location {
-  lat: number
-  lng: number
-  updatedAt: number
-  isSharing?: boolean
-}
+import type { UserLocation } from '../../types'
 
 interface TrackPWIDPageProps {
   pwidPhoneNumber: string
@@ -27,7 +21,7 @@ export function TrackPWIDPage({
 }: TrackPWIDPageProps) {
   const { top } = useSafeArea()
   const router = useRouter()
-  const [location, setLocation] = useState<Location | null>(null)
+  const [location, setLocation] = useState<UserLocation | null>(null)
   const [_, setLocationUpdated] = useState<string>('')
   const [loading, setLoading] = useState(true)
   const actionSheetRef = useRef<ActionSheetRef>(null)

--- a/packages/common/src/pages/track-pwid/TrackPWIDPage.tsx
+++ b/packages/common/src/pages/track-pwid/TrackPWIDPage.tsx
@@ -13,6 +13,7 @@ interface Location {
   lat: number
   lng: number
   updatedAt: number
+  isSharing?: boolean
 }
 
 interface TrackPWIDPageProps {
@@ -65,7 +66,7 @@ export function TrackPWIDPage({
     }
   }
 
-  const isSharing = !!location
+  const isSharing = !!location?.isSharing
   const statusColor = isSharing ? '#CBF4DF' : '#F7CBC8'
   const statusTextColor = isSharing ? '#209D5E' : '#E13F33'
   const statusText = isSharing ? 'Online' : 'Offline'

--- a/packages/common/src/services/userService.native.ts
+++ b/packages/common/src/services/userService.native.ts
@@ -73,7 +73,9 @@ export const userService: IUserService = {
 
   updatePWIDLocation: async (phoneNumber: string, location: UserLocation) => {
     try {
-      await database().ref(`users/${phoneNumber}/location`).set(location)
+      await database()
+        .ref(`users/${phoneNumber}/location`)
+        .set({ ...location, isSharing: true })
       await database().ref(`users/${phoneNumber}/updatedAt`).set(Date.now())
     } catch (error) {
       console.error('Error updating PWID location:', error)
@@ -81,12 +83,14 @@ export const userService: IUserService = {
     }
   },
 
-  clearPWIDLocation: async (phoneNumber: string) => {
+  stopPWIDLocationSharing: async (phoneNumber: string) => {
     try {
-      await database().ref(`users/${phoneNumber}/location`).remove()
+      await database()
+        .ref(`users/${phoneNumber}/location`)
+        .update({ isSharing: false, updatedAt: Date.now() })
       await database().ref(`users/${phoneNumber}/updatedAt`).set(Date.now())
     } catch (error) {
-      console.error('Error clearing PWID location:', error)
+      console.error('Error stopping PWID location sharing:', error)
       throw error
     }
   },
@@ -184,7 +188,7 @@ export const userService: IUserService = {
 export const {
   createUser,
   updatePWIDLocation,
-  clearPWIDLocation,
+  stopPWIDLocationSharing,
   getUserData,
   updatePWIDCaregiver,
   storeFCMToken,

--- a/packages/common/src/services/userService.native.ts
+++ b/packages/common/src/services/userService.native.ts
@@ -87,7 +87,7 @@ export const userService: IUserService = {
     try {
       await database()
         .ref(`users/${phoneNumber}/location`)
-        .update({ isSharing: false, updatedAt: Date.now() })
+        .update({ isSharing: false })
       await database().ref(`users/${phoneNumber}/updatedAt`).set(Date.now())
     } catch (error) {
       console.error('Error stopping PWID location sharing:', error)

--- a/packages/common/src/services/userService.native.ts
+++ b/packages/common/src/services/userService.native.ts
@@ -75,7 +75,7 @@ export const userService: IUserService = {
     try {
       await database()
         .ref(`users/${phoneNumber}/location`)
-        .set({ ...location, isSharing: true })
+        .set(location)
       await database().ref(`users/${phoneNumber}/updatedAt`).set(Date.now())
     } catch (error) {
       console.error('Error updating PWID location:', error)

--- a/packages/common/src/services/userService.ts
+++ b/packages/common/src/services/userService.ts
@@ -8,7 +8,7 @@ export interface IUserService {
     initialData?: Partial<UserData>
   ): Promise<UserData>
   updatePWIDLocation(phoneNumber: string, location: UserLocation): Promise<void>
-  clearPWIDLocation(phoneNumber: string): Promise<void>
+  stopPWIDLocationSharing(phoneNumber: string): Promise<void>
   getUserData(phoneNumber: string): Promise<UserData | null>
   updatePWIDCaregiver(pwidPhone: string, caregiverPhone: string): Promise<void>
   storeFCMToken(phoneNumber: string, fcmToken: string): Promise<void>

--- a/packages/common/src/services/userService.web.ts
+++ b/packages/common/src/services/userService.web.ts
@@ -94,10 +94,7 @@ export const userService: IUserService = {
   updatePWIDLocation: async (phoneNumber: string, location: UserLocation) => {
     try {
       const db = getDatabaseInstance()
-      await set(ref(db, `users/${phoneNumber}/location`), {
-        ...location,
-        isSharing: true
-      })
+      await set(ref(db, `users/${phoneNumber}/location`), location)
       await set(ref(db, `users/${phoneNumber}/updatedAt`), Date.now())
     } catch (error) {
       console.error('Error updating PWID location:', error)

--- a/packages/common/src/services/userService.web.ts
+++ b/packages/common/src/services/userService.web.ts
@@ -7,8 +7,8 @@ import {
   orderByChild,
   query,
   ref,
-  remove,
-  set
+  set,
+  update
 } from 'firebase/database'
 import type {
   CaregiverUser,
@@ -94,7 +94,10 @@ export const userService: IUserService = {
   updatePWIDLocation: async (phoneNumber: string, location: UserLocation) => {
     try {
       const db = getDatabaseInstance()
-      await set(ref(db, `users/${phoneNumber}/location`), location)
+      await set(ref(db, `users/${phoneNumber}/location`), {
+        ...location,
+        isSharing: true
+      })
       await set(ref(db, `users/${phoneNumber}/updatedAt`), Date.now())
     } catch (error) {
       console.error('Error updating PWID location:', error)
@@ -102,13 +105,16 @@ export const userService: IUserService = {
     }
   },
 
-  clearPWIDLocation: async (phoneNumber: string) => {
+  stopPWIDLocationSharing: async (phoneNumber: string) => {
     try {
       const db = getDatabaseInstance()
-      await remove(ref(db, `users/${phoneNumber}/location`))
+      await update(ref(db, `users/${phoneNumber}/location`), {
+        isSharing: false,
+        updatedAt: Date.now()
+      })
       await set(ref(db, `users/${phoneNumber}/updatedAt`), Date.now())
     } catch (error) {
-      console.error('Error clearing PWID location:', error)
+      console.error('Error stopping PWID location sharing:', error)
       throw error
     }
   },
@@ -219,7 +225,7 @@ export const userService: IUserService = {
 export const {
   createUser,
   updatePWIDLocation,
-  clearPWIDLocation,
+  stopPWIDLocationSharing,
   getUserData,
   updatePWIDCaregiver,
   storeFCMToken,

--- a/packages/common/src/services/userService.web.ts
+++ b/packages/common/src/services/userService.web.ts
@@ -106,8 +106,7 @@ export const userService: IUserService = {
     try {
       const db = getDatabaseInstance()
       await update(ref(db, `users/${phoneNumber}/location`), {
-        isSharing: false,
-        updatedAt: Date.now()
+        isSharing: false
       })
       await set(ref(db, `users/${phoneNumber}/updatedAt`), Date.now())
     } catch (error) {

--- a/packages/common/src/types/user.ts
+++ b/packages/common/src/types/user.ts
@@ -22,6 +22,7 @@ export interface UserLocation {
   lat: number
   lng: number
   updatedAt: number
+  isSharing?: boolean
 }
 
 interface BaseUser {

--- a/packages/common/src/types/user.ts
+++ b/packages/common/src/types/user.ts
@@ -22,7 +22,7 @@ export interface UserLocation {
   lat: number
   lng: number
   updatedAt: number
-  isSharing?: boolean
+  isSharing: boolean
 }
 
 interface BaseUser {


### PR DESCRIPTION
Persist last-known location and updated at time after location sharing stops.

Currently, the PWID's location data is cleared when location sharing ends. This leads to a "Updated unknown" shown on the caregiver dashboard with no location data.

**Changes made** 
- new field added to user's location node - `isSharing`: boolean, used to derive Online / Offline status in CaregiverHome and TrackPWIDPage, instead of relying on the presence of PWID's location data
- When location sharing ends, `isSharing` is toggled to false, `updatedAt` time refreshes, and leaves the last known lat lng coordinates intact
- On location sharing update, `updatePWIDLocation` sets `isSharing` to true
- renamed naming from `clearPWIDLocation` to `stopPWIDLocationSharing`
- guard stopPWIDLocationSharing against invocations before sharing was ever started, as switching from remove() to update() in stopPWIDLocationSharing would otherwise create a malformed { isSharing: false, updatedAt } node with no coordinates